### PR TITLE
Validate the windows label before using it.

### DIFF
--- a/plastik-for-qubes/kwin-client/plastikclient.cpp
+++ b/plastik-for-qubes/kwin-client/plastikclient.cpp
@@ -276,6 +276,11 @@ void PlastikClient::get_qubes_label() {
     }
 
     int label = (int)*data;
+    if (label < 0 || label >= MAX_QUBES_LABELS) {
+        // Out of range.  // Make sure we don't crash, and
+        // signal something is wrong with a red label.
+        label = QUBES_LABEL_RED;
+    }
     qubes_label = QubesLabels[label];
 }
 


### PR DESCRIPTION
This isn't really a security risk since the windows label can only be set from dom0. Nonetheless e.g. a bad -l value passed from qubes-guid can cause a crash.

Make a best effort to indicate when something is wrong by using a red label.

It may also be worth validating the -l parameter in qubes-guid too.
