### PR TITLE
Update version defs to match the working kde-baseapps

### DIFF
--- a/kde-settings/kde-settings.spec
+++ b/kde-settings/kde-settings.spec
@@ -1,9 +1,8 @@
 # THIS SPECFILE IS FOR F18 ONLY!
-
 %if 0%{?qubes_builder}
 %define _sourcedir %(pwd)/kde-settings
-%define epoch %(cat epoch)
 %endif
+%{!?epoch: %define epoch %(cat epoch)}
 
 %global rel 19
 %global system_kde_theme_ver 17.91

--- a/qubes-kde-dom0/qubes-kde-dom0.spec
+++ b/qubes-kde-dom0/qubes-kde-dom0.spec
@@ -2,8 +2,9 @@
 
 %if 0%{?qubes_builder}
 %define _sourcedir %(pwd)/qubes-kde-dom0
-%define version %(cat version)
 %endif
+%{!?version: %define version %(cat version)}
+
 
 Name:    qubes-kde-dom0
 Summary: Metapackage for installing all KDE components needed for Qubes Dom0


### PR DESCRIPTION
Fix the spec files to provide correct values when called from e.g. dist-build-dep where the package vars aren't made available.
