### PR TITLE
Add missing dependency on patch

### DIFF
--- a/kde-settings-qubes.spec.in
+++ b/kde-settings-qubes.spec.in
@@ -26,6 +26,7 @@ Requires: plasma-workspace
 Requires: plasma-workspace-libs
 Requires: sddm
 Requires: sddm-breeze
+Requires(pre): patch
 
 # Drop previous Qubes packages
 Requires: kde-baseapps > 16.08.3


### PR DESCRIPTION
Fix for install error:
```
[3/4] Reinstalling kde-settings-qubes-0:6.2.0-2.fc41.noarch           100% | 135.3 KiB/s |  13.8 KiB |  00m00s
>>> Running %triggerin scriptlet: kde-settings-qubes-0:6.2.0-2.fc41.noarch
>>> Non-critical error in %triggerin scriptlet: kde-settings-qubes-0:6.2.0-2.fc41.noarch
>>> Scriptlet output:
>>> /var/tmp/rpm-tmp.VlCSXj: line 4: patch: command not found
>>>
>>> [RPM] %triggerin(kde-settings-qubes-6.2.0-2.fc41.noarch) scriptlet failed, exit status 127
```