### PR TITLE
Add dependencies for X11 Plasma KDE Desktop Environment

### DIFF
--- a/kde-settings-qubes.spec.in
+++ b/kde-settings-qubes.spec.in
@@ -24,6 +24,7 @@ Requires: oxygen-cursor-themes
 Requires: oxygen-icon-theme
 Requires: plasma-workspace
 Requires: plasma-workspace-libs
+Requires: plasma-workspace-x11
 Requires: sddm
 Requires: sddm-breeze
 


### PR DESCRIPTION
Making KDE work on a fresh Qubes 4.2.4 install. Right now this dependency isnt pulled and the desktop session defaults to wayland without this package.